### PR TITLE
use slash syntax instead of deprecated `in`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val nonPublishSettings = Seq(
 
 lazy val publishSettings = Seq(
   publishMavenStyle := true,
-  publishArtifact in Test := false,
+  Test / publishArtifact := false,
   pomExtra :=
     <url>https://github.com/tototoshi/scala-fixture</url>
     <licenses>
@@ -36,7 +36,7 @@ lazy val commonSettings = Seq(
   crossScalaVersions := Seq("2.13.6", "2.12.13"),
   organization := "com.github.tototoshi",
   scalacOptions ++= Seq("-deprecation", "-language:_"),
-  parallelExecution in Test := false,
+  Test / parallelExecution := false,
   publishTo := {
     val nexus = "https://oss.sonatype.org/"
     if (version.value.trim.endsWith("SNAPSHOT")) Some("snapshots" at nexus + "content/repositories/snapshots")


### PR DESCRIPTION
```
/home/runner/work/scala-fixture/scala-fixture/build.sbt:9: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
  publishArtifact in Test := false,
                  ^
/home/runner/work/scala-fixture/scala-fixture/build.sbt:39: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
  parallelExecution in Test := false,
                    ^
```

https://github.com/sbt/sbt/commit/e6fec6b1db5f212a74bf5e3766b9b70f2d983f24
https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash