### PR TITLE
fix warning. avoid `Class#newInstance`

### DIFF
--- a/core/src/main/scala/com/github/tototoshi/fixture/JavaFixtureScriptScanner.scala
+++ b/core/src/main/scala/com/github/tototoshi/fixture/JavaFixtureScriptScanner.scala
@@ -7,7 +7,7 @@ private[fixture] class JavaFixtureScriptScanner(classLoader: ClassLoader, script
   override def scan(scriptName: String): Option[FixtureScript] = {
     try {
       val className = if (scriptPackage == "") scriptName else scriptPackage + "." + scriptName
-      Some(Class.forName(className, true, classLoader).newInstance().asInstanceOf[FixtureScript])
+      Some(Class.forName(className, true, classLoader).getConstructor().newInstance().asInstanceOf[FixtureScript])
     } catch {
       case e: ClassNotFoundException => None
     }


### PR DESCRIPTION
https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Class.html#newInstance()

> Deprecated.
This method propagates any exception thrown by the nullary constructor, including a checked exception. Use of this method effectively bypasses the compile-time exception checking that would otherwise be performed by the compiler. The [Constructor.newInstance](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/reflect/Constructor.html#newInstance(java.lang.Object...)) method avoids this problem by wrapping any exception thrown by the constructor in a (checked) [InvocationTargetException](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/reflect/InvocationTargetException.html).
